### PR TITLE
Populate home and about pages with content

### DIFF
--- a/about.markdown
+++ b/about.markdown
@@ -4,15 +4,10 @@ title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+This site collects notes and projects maintained by **rakan317**. It serves as a
+hub for repository listings, write-ups of challenges, and general resources
+shared with the community.
 
-You can find the source code for Minima at GitHub:
-[jekyll][jekyll-organization] /
-[minima](https://github.com/jekyll/minima)
-
-You can find the source code for Jekyll at GitHub:
-[jekyll][jekyll-organization] /
-[jekyll](https://github.com/jekyll/jekyll)
-
-
-[jekyll-organization]: https://github.com/jekyll
+Built with [Jekyll](https://jekyllrb.com/) and hosted on GitHub Pages, the site
+is open source. Visit the [Repositories](/repos/) page to explore the code or
+head over to [Writeups](/writeups/) for detailed articles and notes.

--- a/index.markdown
+++ b/index.markdown
@@ -1,6 +1,17 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
 layout: home
+title: Home
 ---
+
+Welcome to my corner of the internet. Here you'll find links to projects,
+write‑ups, and resources gathered over time.
+
+Explore some sections of the site:
+
+- [About](/about/)
+- [Repositories](/repos/)
+- [Writeups](/writeups/)
+- [Scam Awareness](/scam/)
+
+The latest post is available at the bottom of this page. Stay tuned for more
+updates!


### PR DESCRIPTION
## Summary
- Add welcome text and navigation links to home page
- Replace placeholder about page with information on the site and links

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689ba28857148323a8cdd71621db8c59