### PR TITLE
Enable dark theme for blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,9 @@ plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
 
+minima:
+  skin: dark
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
## Summary
- switch site to dark mode by setting the Minima theme's skin to `dark`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689db0e5d1088323aa62ae75ededbdd2